### PR TITLE
feat: add customizable theme toggle with database persistence

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
       - "3000:3000"
     environment:
       - DATABASE_URL=${DATABASE_URL:-postgresql://postgres:postgres@db:5432/todoapp}
+      - PRISMA_DATABASE_URL=${PRISMA_DATABASE_URL:-postgresql://postgres:postgres@db:5432/todoapp}
+      - DIRECT_URL=${DIRECT_URL:-postgresql://postgres:postgres@db:5432/todoapp}
       - NEXTAUTH_URL=${NEXTAUTH_URL:-http://localhost:3000}
       - NEXTAUTH_SECRET=${NEXTAUTH_SECRET}
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}

--- a/prisma/migrations/20251226122738_add_user_theme/migration.sql
+++ b/prisma/migrations/20251226122738_add_user_theme/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "theme" TEXT NOT NULL DEFAULT 'system';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,7 @@ model User {
   emailVerified DateTime?
   password      String?   // Nullable for OAuth users
   image         String?
+  theme         String    @default("system") // "light" | "dark" | "system"
   accounts      Account[]
   sessions      Session[]
   todos         Todo[]

--- a/src/app/api/user/theme/route.ts
+++ b/src/app/api/user/theme/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+const VALID_THEMES = ['light', 'dark', 'system'] as const;
+type Theme = (typeof VALID_THEMES)[number];
+
+export async function PATCH(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+    const { theme } = body;
+
+    if (!theme || !VALID_THEMES.includes(theme)) {
+      return NextResponse.json(
+        { error: 'Invalid theme. Must be one of: light, dark, system' },
+        { status: 400 }
+      );
+    }
+
+    const updatedUser = await prisma.user.update({
+      where: { id: session.user.id },
+      data: { theme: theme as Theme },
+      select: { id: true, theme: true },
+    });
+
+    return NextResponse.json(updatedUser);
+  } catch (error) {
+    console.error('Error updating theme:', error);
+    return NextResponse.json(
+      { error: 'Failed to update theme' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { theme: true },
+    });
+
+    return NextResponse.json({ theme: user?.theme ?? 'system' });
+  } catch (error) {
+    console.error('Error fetching theme:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch theme' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -11,6 +11,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { ThemeToggle } from '@/components/theme-toggle'
 
 export function Header() {
   const { data: session } = useSession()
@@ -38,7 +39,9 @@ export function Header() {
       <div className="flex h-16 items-center justify-between px-6">
         <h1 className="text-xl font-semibold">Todo App</h1>
 
-        {session?.user && (
+        <div className="flex items-center gap-2">
+          <ThemeToggle />
+          {session?.user && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="ghost" className="relative h-8 w-8 rounded-full">
@@ -63,7 +66,8 @@ export function Header() {
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
-        )}
+          )}
+        </div>
       </div>
     </header>
   )

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import * as React from 'react'
+import { useTheme } from 'next-themes'
+import { useSession } from 'next-auth/react'
+import { Sun, Moon, Monitor } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+
+const themes = [
+  { value: 'light', label: 'Light', icon: Sun },
+  { value: 'dark', label: 'Dark', icon: Moon },
+  { value: 'system', label: 'System', icon: Monitor },
+] as const
+
+type ThemeValue = (typeof themes)[number]['value']
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+  const { data: session } = useSession()
+  const [mounted, setMounted] = React.useState(false)
+
+  // Prevent hydration mismatch
+  React.useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  // Sync theme from database when user logs in
+  React.useEffect(() => {
+    if (session?.user && mounted) {
+      fetch('/api/user/theme')
+        .then((res) => res.json())
+        .then((data) => {
+          if (data.theme && data.theme !== theme) {
+            setTheme(data.theme)
+          }
+        })
+        .catch((error) => {
+          console.error('Failed to fetch theme preference:', error)
+        })
+    }
+  }, [session?.user, mounted]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleThemeChange = async (newTheme: ThemeValue) => {
+    // Apply immediately via next-themes
+    setTheme(newTheme)
+
+    // Persist to database if logged in
+    if (session?.user) {
+      try {
+        await fetch('/api/user/theme', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ theme: newTheme }),
+        })
+      } catch (error) {
+        // Theme still works locally even if API fails
+        console.error('Failed to save theme preference:', error)
+      }
+    }
+  }
+
+  // Show placeholder during SSR to avoid hydration mismatch
+  if (!mounted) {
+    return (
+      <Button variant="ghost" size="icon" disabled>
+        <Sun className="h-5 w-5" />
+        <span className="sr-only">Toggle theme</span>
+      </Button>
+    )
+  }
+
+  const currentTheme = themes.find((t) => t.value === theme) ?? themes[2]
+  const CurrentIcon = currentTheme.icon
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon">
+          <CurrentIcon className="h-5 w-5" />
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {themes.map(({ value, label, icon: Icon }) => (
+          <DropdownMenuItem
+            key={value}
+            onClick={() => handleThemeChange(value)}
+            className={theme === value ? 'bg-accent' : ''}
+          >
+            <Icon className="mr-2 h-4 w-4" />
+            {label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}


### PR DESCRIPTION
## Summary
- Add theme toggle component in header
- Store theme preference in database for persistence across sessions
- Support light, dark, and system themes

## Test plan
- [x] Theme toggle switches between light/dark/system
- [x] Theme persists after page reload
- [x] Theme syncs with system preference when set to "system"
