### PR TITLE
chore: add .playwright-mcp to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ yarn-error.log*
 next-env.d.ts
 
 /src/generated/prisma
+.playwright-mcp/


### PR DESCRIPTION
## Summary
- Add `.playwright-mcp` directory to gitignore
- Prevents Playwright MCP artifacts from being committed

## Test plan
- [x] Verified .gitignore updated correctly
